### PR TITLE
Bug: 57183

### DIFF
--- a/src/SME.SR.Data/Repositories/Eol/ComponenteCurricularRepository.cs
+++ b/src/SME.SR.Data/Repositories/Eol/ComponenteCurricularRepository.cs
@@ -360,7 +360,12 @@ namespace SME.SR.Data
             };
 
             using var conexao = new SqlConnection(variaveisAmbiente.ConnectionStringEol);
-            return await conexao.QueryAsync<ComponenteCurricular>(query, parametros);
+            var resultado = await conexao.QueryAsync<ComponenteCurricular>(query, parametros);
+
+            if (!consideraHistorico && !resultado.Any())
+                resultado = await conexao.QueryAsync<ComponenteCurricular>(ComponenteCurricularConsultas.BuscarPorAlunosHistorico, parametros);
+
+            return resultado;
         }
     }
 }


### PR DESCRIPTION
Ajuste na geração de boletim, tratando os componentes resgatados em caso de não ser hitórico e não retornar registros, faz a tentativa de retornar considerando a consulta de dados hitóricos.