### PR TITLE
Fix/62488

### DIFF
--- a/src/SME.SR.Application/Queries/Alunos/ObterAlunosTurmasRelatorioBoletim/ObterAlunosTurmasRelatorioBoletimQueryHandler.cs
+++ b/src/SME.SR.Application/Queries/Alunos/ObterAlunosTurmasRelatorioBoletim/ObterAlunosTurmasRelatorioBoletimQueryHandler.cs
@@ -2,6 +2,7 @@
 using SME.SR.Data;
 using SME.SR.Data.Interfaces;
 using SME.SR.Infra;
+using SME.SR.Infra.Utilitarios;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -21,21 +22,45 @@ namespace SME.SR.Application
         public async Task<IEnumerable<IGrouping<string, Aluno>>> Handle(ObterAlunosTurmasRelatorioBoletimQuery request, CancellationToken cancellationToken)
         {
             var alunos = Enumerable.Empty<Aluno>();
+            var alunosOrdenadosPorSituacao = Enumerable.Empty<Aluno>();
 
             if (request.CodigosAlunos?.Length > 0)
+            {
                 alunos = await alunoRepository.ObterPorCodigosAlunoETurma(request.CodigosTurma, request.CodigosAlunos);
-            else
-                alunos = await alunoRepository.ObterPorCodigosTurma(request.CodigosTurma);
-
-            if (!alunos.Any())
-                throw new NegocioException("Não foi possível localizar os alunos");
+                alunosOrdenadosPorSituacao = ObterAlunosPorUltimaSituacao(alunos);
+            }
             else
             {
-                return request.TrazerAlunosInativos ? alunos.OrderBy(a => a.ObterNomeFinal()).GroupBy(a => a.CodigoAluno.ToString()) 
-                                                    : alunos.Where(al => al.CodigoSituacaoMatricula == SituacaoMatriculaAluno.Ativo 
-                                                        || al.CodigoSituacaoMatricula == SituacaoMatriculaAluno.Concluido)
-                                                        .OrderBy(a => a.ObterNomeFinal()).GroupBy(a => a.CodigoAluno.ToString());
+                alunos = await alunoRepository.ObterPorCodigosTurma(request.CodigosTurma);
+                alunosOrdenadosPorSituacao = ObterAlunosPorUltimaSituacao(alunos);
             }
+
+            if (!alunosOrdenadosPorSituacao.Any())
+                throw new NegocioException("Não foi possível localizar os alunos");
+
+            var resultadoAlunos = request.TrazerAlunosInativos ? alunosOrdenadosPorSituacao.OrderBy(a => a.ObterNomeFinal()).GroupBy(a => a.CodigoAluno.ToString())
+                                                : alunosOrdenadosPorSituacao.Where(al => al.CodigoSituacaoMatricula == SituacaoMatriculaAluno.Ativo
+                                                    || al.CodigoSituacaoMatricula == SituacaoMatriculaAluno.Concluido)
+                                                    .OrderBy(a => a.ObterNomeFinal()).GroupBy(a => a.CodigoAluno.ToString());
+            if (!resultadoAlunos.Any())
+                throw new NegocioException("Não foi possível localizar alunos com os filtros definidos.");
+
+            return resultadoAlunos;
+        }
+
+        private IEnumerable<Aluno> ObterAlunosPorUltimaSituacao(IEnumerable<Aluno> listaAlunos)
+        {
+            var listaTemporaria = new List<Aluno>();
+            var listaAlunosOrdenada = new List<Aluno>();
+
+            foreach (var item in listaAlunos)
+            {
+                listaTemporaria = listaAlunos.Where(x => x.CodigoAluno == item.CodigoAluno).ToList();
+                listaAlunosOrdenada.AddRange(listaTemporaria.OrderByDescending(x => x.DataSituacao).Take(1));
+                listaTemporaria.Clear();
+            }
+
+            return listaAlunosOrdenada.DistinctBy(x => x.CodigoAluno);
         }
     }
 }

--- a/src/SME.SR.Workers.SGP/Views/RelatorioBoletimEscolarSimples.cshtml
+++ b/src/SME.SR.Workers.SGP/Views/RelatorioBoletimEscolarSimples.cshtml
@@ -87,7 +87,7 @@
                 @{
                     aluno.ComponentesCurriculares.GroupBy(g => g.Grupo).ToList().ForEach(f =>
                   {
-                      if (f.Key == 3 && ehEJA)
+                      if (f.Key == 3 && ehEJA && aluno.ComponenteCurricularRegencia != null)
                           MontarComponenteCurricularesRegencia(aluno);
                 
                       MontarComponenteCurriculares(f.Select(s=> s));


### PR DESCRIPTION
AB#62488

correção do bug, alunos inativos estavam sendo exibidos pois apesar da ultima situação do aluno ser um estado inativo (desistente) havia registro anterior com "ativo" o que ocasionava na impressão do boletim do aluno mas sem a informação da situação, foi criado uma maneira de buscar a situação atual pegando pela ultima data da situação do aluno, e criei um fluxo alternativo para quando não houver alunos retornados pela busca, @rafalosiamcom favor verificar se o fluxo tá coerente com o negócio, valeu!