### PR TITLE
Bug: 119558

### DIFF
--- a/src/SME.SR.Application/UseCases/RelatorioSondagemMatematicaConsolidadoUseCase.cs
+++ b/src/SME.SR.Application/UseCases/RelatorioSondagemMatematicaConsolidadoUseCase.cs
@@ -45,16 +45,14 @@ namespace SME.SR.Application
                     throw new NegocioException("Não foi possível obter o usuário.");
             }
 
-            DateTime dataReferencia = DateTime.Now;
+            PeriodoCompletoSondagemDto periodo;
 
-            if (filtros.AnoLetivo < 2022 && filtros.Semestre > 0)
-                dataReferencia = await mediator.Send(new ObterDataPeriodoFimSondagemPorSemestreAnoLetivoQuery(filtros.Semestre, filtros.AnoLetivo));
-            else if (filtros.AnoLetivo >= 2022 && filtros.Bimestre > 0)
-                dataReferencia = await mediator.Send(new ObterDataPeriodoFimSondagemPorBimestreAnoLetivoQuery(filtros.Bimestre, filtros.AnoLetivo));
-            else if (filtros.AnoLetivo >= 2023 && filtros.Semestre > 0)
-                dataReferencia = await mediator.Send(new ObterDataPeriodoFimSondagemPorSemestreAnoLetivoQuery(filtros.Semestre, filtros.AnoLetivo));
+            if ((filtros.AnoLetivo < 2022 || filtros.AnoLetivo >= 2023) && filtros.Semestre > 0)
+                periodo = await mediator.Send(new ObterDatasPeriodoSondagemPorSemestreAnoLetivoQuery(filtros.Semestre, filtros.AnoLetivo));
+            else 
+                periodo = await mediator.Send(new ObterDatasPeriodoSondagemPorBimestreAnoLetivoQuery(filtros.Bimestre, filtros.AnoLetivo));
 
-            var quantidadeTotalAlunosUeAno = await mediator.Send(new ObterTotalAlunosPorUeAnoSondagemQuery(filtros.Ano, ue?.Codigo, filtros.AnoLetivo, dataReferencia, filtros.DreCodigo, filtros.Modalidades, true));
+            var quantidadeTotalAlunosUeAno = await mediator.Send(new ObterTotalAlunosPorUeAnoSondagemQuery(filtros.Ano, ue?.Codigo, filtros.AnoLetivo, periodo.PeriodoFim, filtros.DreCodigo, filtros.Modalidades, true, periodo.PeriodoInicio));
 
             var relatorio = await mediator.Send(new ObterSondagemMatNumAutoralConsolidadoQuery()
             {

--- a/src/SME.SR.Data/Repositories/Eol/AlunoRepository.cs
+++ b/src/SME.SR.Data/Repositories/Eol/AlunoRepository.cs
@@ -324,11 +324,11 @@ namespace SME.SR.Data
 									INNER JOIN v_cadastro_unidade_educacao ue
 										ON te.cd_escola = ue.cd_unidade_educacao
 									INNER JOIN alunos_matriculas_norm aln 
-										ON aln.CodigoAluno = m.cd_aluno
+										ON aln.CodigoMatricula = m.cd_matricula
 								WHERE te.an_letivo = @anoLetivo AND
 									  te.cd_tipo_turma = 1 AND
-									  ((mte.cd_situacao_aluno in (1, 6, 10, 13, 5) or (mte.cd_situacao_aluno in (1, 6, 13, 5) and CAST(mte.dt_situacao_aluno AS DATE) < @dataFim))
-									  or (mte.cd_situacao_aluno not in (1, 6, 10, 13, 5)
+									  ((mte.cd_situacao_aluno = 10 or (mte.cd_situacao_aluno in (1, 6, 13, 5) and CAST(aln.DataMatricula AS DATE) < @dataFim))
+									  or (mte.cd_situacao_aluno not in (1, 6, 10, 13, 5) and CAST(aln.DataMatricula AS DATE) <= @dataFim
 									  {(dataReferenciaInicio == null || dataReferenciaInicio == DateTime.MinValue
                                         ? "and mte.dt_situacao_aluno > @dataFim))"
                                         : "and (mte.dt_situacao_aluno > @dataFim or (mte.dt_situacao_aluno > @dataInicio and mte.dt_situacao_aluno <= @dataFim))))"


### PR DESCRIPTION
Ajuste na geração do relatório de Sondagem, ao obter a quantidade de alunos para o consolidade de matemática considerar o período de inicio e fim, equivalente ao que é feito em tela. E alteração na consulta de total de alunos para deixar equivalente a consulta executada pela API/EOL.