### PR TITLE
Refatora parâmetro solicitante para int na devolucao livro do cdep

### DIFF
--- a/src/SME.SR.Data/Interfaces/CDEP/IRelatorioControleLivrosRepository.cs
+++ b/src/SME.SR.Data/Interfaces/CDEP/IRelatorioControleLivrosRepository.cs
@@ -10,6 +10,6 @@ namespace SME.SR.Data.Interfaces
         Task<IEnumerable<AcervoSolicitacaoDto>> ObterRelatorioControleLivrosEmpresados(long[] tiposAcervosPermitidos, string solicitante, string tombo, List<SituacaoEmprestimo> situacaoEmprestimo, bool? somenteDevolvidos);
         Task<IEnumerable<ControleAcervoDTO>> ObterRelatorioControleAcervos(long[] tiposAcervosPermitidos, TipoAcervo? tipoAcervo, SituacaoAcervo? situacaoAcervo);
         Task<IEnumerable<ControleAcervoAutorDTO>> ObterRelatorioControleAcervosAutor(long[] tiposAcervosPermitidos, TipoAcervo? tipoAcervo, List<int> autores);
-        Task<IEnumerable<AcervoDevolucaoDto>> ObterRelatorioControleDevolucaoLivros(long[] tiposAcervosPermitidos, int? solicitante, bool? somenteAtrasados = false);
+        Task<IEnumerable<AcervoDevolucaoDto>> ObterRelatorioControleDevolucaoLivros(long[] tiposAcervosPermitidos, string solicitante, bool? somenteAtrasados = false);
     }
 }

--- a/src/SME.SR.Data/Interfaces/CDEP/IRelatorioControleLivrosRepository.cs
+++ b/src/SME.SR.Data/Interfaces/CDEP/IRelatorioControleLivrosRepository.cs
@@ -10,6 +10,6 @@ namespace SME.SR.Data.Interfaces
         Task<IEnumerable<AcervoSolicitacaoDto>> ObterRelatorioControleLivrosEmpresados(long[] tiposAcervosPermitidos, string solicitante, string tombo, List<SituacaoEmprestimo> situacaoEmprestimo, bool? somenteDevolvidos);
         Task<IEnumerable<ControleAcervoDTO>> ObterRelatorioControleAcervos(long[] tiposAcervosPermitidos, TipoAcervo? tipoAcervo, SituacaoAcervo? situacaoAcervo);
         Task<IEnumerable<ControleAcervoAutorDTO>> ObterRelatorioControleAcervosAutor(long[] tiposAcervosPermitidos, TipoAcervo? tipoAcervo, List<int> autores);
-        Task<IEnumerable<AcervoDevolucaoDto>> ObterRelatorioControleDevolucaoLivros(long[] tiposAcervosPermitidos, List<int> solicitante, bool? somenteAtrasados = false);
+        Task<IEnumerable<AcervoDevolucaoDto>> ObterRelatorioControleDevolucaoLivros(long[] tiposAcervosPermitidos, int? solicitante, bool? somenteAtrasados = false);
     }
 }

--- a/src/SME.SR.Data/Repositories/CDEP/RelatorioControleLivrosRepository.cs
+++ b/src/SME.SR.Data/Repositories/CDEP/RelatorioControleLivrosRepository.cs
@@ -182,7 +182,7 @@ namespace SME.SR.Data
             return await conexao.QueryAsync<ControleAcervoAutorDTO>(query.ToString(), parametros);
         }
 
-        public async Task<IEnumerable<AcervoDevolucaoDto>> ObterRelatorioControleDevolucaoLivros(long[] tiposAcervosPermitidos, int? solicitante, bool? somenteAtrasados = false)
+        public async Task<IEnumerable<AcervoDevolucaoDto>> ObterRelatorioControleDevolucaoLivros(long[] tiposAcervosPermitidos, string solicitante, bool? somenteAtrasados = false)
         {
             var query = new StringBuilder();
             query.AppendLine(@"
@@ -220,9 +220,9 @@ namespace SME.SR.Data
                 }
             }
 
-            if (solicitante != null && solicitante > 0)
+            if (!string.IsNullOrWhiteSpace(solicitante))
             {
-                query.AppendLine(" AND u.id = @Solicitante");
+                query.AppendLine(" AND u.login = @Solicitante");
                 parametros.Add("Solicitante", solicitante);
             }
 

--- a/src/SME.SR.Data/Repositories/CDEP/RelatorioControleLivrosRepository.cs
+++ b/src/SME.SR.Data/Repositories/CDEP/RelatorioControleLivrosRepository.cs
@@ -182,7 +182,7 @@ namespace SME.SR.Data
             return await conexao.QueryAsync<ControleAcervoAutorDTO>(query.ToString(), parametros);
         }
 
-        public async Task<IEnumerable<AcervoDevolucaoDto>> ObterRelatorioControleDevolucaoLivros(long[] tiposAcervosPermitidos, List<int> solicitante, bool? somenteAtrasados = false)
+        public async Task<IEnumerable<AcervoDevolucaoDto>> ObterRelatorioControleDevolucaoLivros(long[] tiposAcervosPermitidos, int? solicitante, bool? somenteAtrasados = false)
         {
             var query = new StringBuilder();
             query.AppendLine(@"
@@ -220,9 +220,9 @@ namespace SME.SR.Data
                 }
             }
 
-            if (solicitante?.Count > 0)
+            if (solicitante != null && solicitante > 0)
             {
-                query.AppendLine(" AND u.id = ANY(@Solicitante)");
+                query.AppendLine(" AND u.id = @Solicitante");
                 parametros.Add("Solicitante", solicitante);
             }
 

--- a/src/SME.SR.Infra/Dtos/Relatorios/CDEP/FiltroRelatorioControleDevolucaoLivro.cs
+++ b/src/SME.SR.Infra/Dtos/Relatorios/CDEP/FiltroRelatorioControleDevolucaoLivro.cs
@@ -2,7 +2,7 @@
 {
     public class FiltroRelatorioControleDevolucaoLivro
     {
-        public int? Solicitante { get; set; }
+        public string Solicitante { get; set; }
         public string Usuario { get; set; }
         public string UsuarioRF { get; set; }
         public long[] TiposAcervosPermitidos { get; set; }

--- a/src/SME.SR.Infra/Dtos/Relatorios/CDEP/FiltroRelatorioControleDevolucaoLivro.cs
+++ b/src/SME.SR.Infra/Dtos/Relatorios/CDEP/FiltroRelatorioControleDevolucaoLivro.cs
@@ -1,10 +1,8 @@
-﻿using System.Collections.Generic;
-
-namespace SME.SR.Infra.Dtos.Relatorios.CDEP
+﻿namespace SME.SR.Infra.Dtos.Relatorios.CDEP
 {
     public class FiltroRelatorioControleDevolucaoLivro
     {
-        public List<int> Solicitante { get; set; }
+        public int? Solicitante { get; set; }
         public string Usuario { get; set; }
         public string UsuarioRF { get; set; }
         public long[] TiposAcervosPermitidos { get; set; }


### PR DESCRIPTION
O parâmetro "solicitante" foi alterado de List<int> para int? no repositório, na interface e no DTO para o método "ObterRelatorioControleDevolucaoLivros". Isso simplifica o filtro para suportar um único solicitante opcional em vez de uma lista.