### PR TITLE
Adicionar quantidade ao relatório de frequência mensal

### DIFF
--- a/src/SME.SR.Application/Commands/ExportacaoExcel/GerarExcelGenerico/GerarExcelGenericoCommandHandler.cs
+++ b/src/SME.SR.Application/Commands/ExportacaoExcel/GerarExcelGenerico/GerarExcelGenericoCommandHandler.cs
@@ -47,6 +47,8 @@ namespace SME.SR.Application
                     if (request.PossuiNotaRodape)
                         MontarRodape(request, worksheet);
 
+                    worksheet.Columns().AdjustToContents();
+
                     var caminhoBase = AppDomain.CurrentDomain.BaseDirectory;
                     var caminhoParaSalvar = Path.Combine(caminhoBase, $"relatorios", request.CodigoCorrelacao.ToString());
 
@@ -149,9 +151,6 @@ namespace SME.SR.Application
             worksheet.Cells(colunaNome).Style.Border.LeftBorderColor = XLColor.Black;
 
             worksheet.Cells(colunaNome).Style.Font.Bold = true;
-
-            worksheet.Columns().AdjustToContents();
-
         }
         private static void CorpoFormataStylo(IXLWorksheet worksheet, string celulaNome)
         {

--- a/src/SME.SR.Application/Queries/RelatorioFrequenciaGlobal/ObterRelatorioDeFrequenciaGlobalQueryHandler.cs
+++ b/src/SME.SR.Application/Queries/RelatorioFrequenciaGlobal/ObterRelatorioDeFrequenciaGlobalQueryHandler.cs
@@ -76,8 +76,11 @@ namespace SME.SR.Application
                                         CodigoEOL = item.CodigoEol,
                                         Estudante = dadosSituacaoAluno.NomeFinalAluno,
                                         NumeroChamadda = dadosSituacaoAluno.NroChamada,
-                                        PercentualFrequencia = item.Percentual
-                                    });
+                                        PercentualFrequencia = item.Percentual,
+                                        QuantidadeCompensacoesAusencias = item.QuantidadeCompensacoes,
+                                        QuantidadeAusencias = item.QuantidadeAusencias,
+                                        QuantidadeAulas = item.QuantidadeAulas
+                                });
                             }
                         }
                     }

--- a/src/SME.SR.Application/UseCases/RelatorioFrequenciaGlobalUseCase.cs
+++ b/src/SME.SR.Application/UseCases/RelatorioFrequenciaGlobalUseCase.cs
@@ -1,6 +1,5 @@
 ﻿using MediatR;
 using SME.SR.Application.Interfaces;
-using SME.SR.Data;
 using SME.SR.Infra;
 using SME.SR.Infra.Extensions;
 using SME.SR.Infra.Utilitarios;
@@ -17,7 +16,7 @@ namespace SME.SR.Application
         {
         }
 
-        public delegate Task OpcaoRelatorio(List<FrequenciaGlobalDto> listaDeFrequencia, Guid codigoCorrelacao);        
+        public delegate Task OpcaoRelatorio(List<FrequenciaGlobalDto> listaDeFrequencia, Guid codigoCorrelacao);
 
         public async Task Executar(FiltroRelatorioDto request)
         {
@@ -27,13 +26,13 @@ namespace SME.SR.Application
 
             if (filtroTodos)
                 await mediator.Send(new SalvarLogViaRabbitCommand($"Log monitoramento Relatório Frequência Mensal {logId}", LogNivel.Informacao, $"Consultando dados e populando DTO"));
-            
+
             var listaDeFrenquenciaGlobal = await mediator.Send(new ObterRelatorioDeFrequenciaGlobalQuery(filtroRelatorio));
 
             if (filtroTodos)
                 await mediator.Send(new SalvarLogViaRabbitCommand($"Log monitoramento Relatório Frequência Mensal {logId}", LogNivel.Informacao, $"DTO populado"));
 
-            if (listaDeFrenquenciaGlobal?.Any() != true)                
+            if (listaDeFrenquenciaGlobal?.Any() != true)
                 throw new NegocioException($"Não foi possível localizar informações com os filtros selecionados");
             else
             {
@@ -78,12 +77,15 @@ namespace SME.SR.Application
                     NomeUe = item.UeNome,
                     NomeTurma = item.Turma,
                     CodigoTurma = item.TurmaCodigo,
-                    NomeMes  = ObterNomeMesReferencia(item.Mes),
+                    NomeMes = ObterNomeMesReferencia(item.Mes),
                     ValorMes = item.Mes,
                     CodigoAluno = item.CodigoEOL,
                     NumeroAluno = item.NumeroChamadda,
                     NomeAluno = item.Estudante,
-                    ProcentagemFrequencia = item.PercentualFrequencia
+                    ProcentagemFrequencia = item.PercentualFrequencia,
+                    QuantidadeAulas = item.QuantidadeAulas,
+                    QuantidadeAusencias = item.QuantidadeAusencias,
+                    QuantidadeCompensacoes = item.QuantidadeCompensacoesAusencias
                 };
                 dto.Add(frequencia);
             }
@@ -99,7 +101,7 @@ namespace SME.SR.Application
         {
             cabecalhoDto.NomeTurma = await ObterNomeTurma(filtroRelatorio);
 
-            await ObterNomeDreUe(filtroRelatorio.CodigoDre, filtroRelatorio.CodigoUe,cabecalhoDto);
+            await ObterNomeDreUe(filtroRelatorio.CodigoDre, filtroRelatorio.CodigoUe, cabecalhoDto);
             cabecalhoDto.AnoLetivo = filtroRelatorio.AnoLetivo;
             cabecalhoDto.NomeModalidade = filtroRelatorio.Modalidade.Name();
             cabecalhoDto.RfUsuarioSolicitante = filtroRelatorio.UsuarioRf;

--- a/src/SME.SR.Data/Repositories/Sgp/FrequenciaAlunoRepository.cs
+++ b/src/SME.SR.Data/Repositories/Sgp/FrequenciaAlunoRepository.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.EntityFrameworkCore.Metadata.Internal;
-using Npgsql;
+﻿using Npgsql;
 using SME.SR.Data.Interfaces;
 using SME.SR.Infra;
 using SME.SR.Infra.Dtos;
@@ -9,9 +8,11 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using SME.SR.Infra.Dtos.FrequenciaMensal;
+using System.Diagnostics.CodeAnalysis;
 
 namespace SME.SR.Data
 {
+    [ExcludeFromCodeCoverage]
     public class FrequenciaAlunoRepository : IFrequenciaAlunoRepository
     {
         private readonly VariaveisAmbiente variaveisAmbiente;
@@ -601,7 +602,10 @@ namespace SME.SR.Data
                                 t.turma_id AS TurmaCodigo,
                                 t.nome as TurmaNome,
                                 cfam.aluno_codigo as CodigoEol,
-                                cfam.percentual
+                                cfam.percentual,
+                                cfam.quantidade_ausencias as QuantidadeAusencias,
+                                cfam.quantidade_aulas as QuantidadeAulas,
+                                cfam.quantidade_compensacoes as QuantidadeCompensacoes
                             from consolidacao_frequencia_aluno_mensal cfam
                                 inner join turma t on t.id = cfam.turma_id
                                 inner join ue u on u.id = t.ue_id

--- a/src/SME.SR.Infra/Dtos/Relatorios/FrequenciaGlobal/FrequenciaAlunoMensalConsolidadoDto.cs
+++ b/src/SME.SR.Infra/Dtos/Relatorios/FrequenciaGlobal/FrequenciaAlunoMensalConsolidadoDto.cs
@@ -13,5 +13,8 @@
         public string TurmaCodigo { get; set; }
         public string CodigoEol { get; set; }
         public decimal Percentual { get; set; }
+        public int QuantidadeAulas { get; set; }
+        public int QuantidadeAusencias { get; set; }
+        public int QuantidadeCompensacoes { get; set; }
     }
 }

--- a/src/SME.SR.Infra/Dtos/Relatorios/FrequenciaGlobal/FrequenciaGlobalDto.cs
+++ b/src/SME.SR.Infra/Dtos/Relatorios/FrequenciaGlobal/FrequenciaGlobalDto.cs
@@ -23,7 +23,7 @@ namespace SME.SR.Infra
         public string TurmaCodigo { get; set; }
 
         [Display(Description = "Turma")]
-        public string Turma {  get; set; }
+        public string Turma { get; set; }
 
         [Display(Description = "Código EOL")]
         public string CodigoEOL { get; set; }
@@ -33,6 +33,15 @@ namespace SME.SR.Infra
 
         [Display(Description = "Estudante")]
         public string Estudante { get; set; }
+
+        [Display(Description = "Quant. Aulas")]
+        public int QuantidadeAulas { get; set; }
+
+        [Display(Description = "Quant. Ausências")]
+        public int QuantidadeAusencias { get; set; }
+
+        [Display(Description = "Quant. Comp. Ausências")]
+        public int QuantidadeCompensacoesAusencias { get; set; }
 
         [Display(Description = "% Frequência")]
         public decimal? PercentualFrequencia { get; set; }

--- a/src/SME.SR.Infra/Dtos/Relatorios/FrequenciaGlobal/FrequenciaMensalDto.cs
+++ b/src/SME.SR.Infra/Dtos/Relatorios/FrequenciaGlobal/FrequenciaMensalDto.cs
@@ -13,6 +13,9 @@
         public string CodigoAluno { get; set; }
         public string NumeroAluno { get; set; }
         public string NomeAluno { get; set; }
+        public int QuantidadeAulas { get; set; }
+        public int QuantidadeAusencias { get; set; }
+        public int QuantidadeCompensacoes { get; set; }
         public decimal? ProcentagemFrequencia { get; set; }
     }
 }

--- a/src/SME.SR.Infra/RelatorioPaginado/Preparador/PreparadorDeRelatorioPaginadoFrequenciaGlobalMensal.cs
+++ b/src/SME.SR.Infra/RelatorioPaginado/Preparador/PreparadorDeRelatorioPaginadoFrequenciaGlobalMensal.cs
@@ -80,9 +80,30 @@ namespace SME.SR.Infra
                 },
                 new Coluna<FrequenciaMensalDto>()
                 {
-                    Largura = 86,
+                    Largura = 62,
                     Titulo = "NOME",
                     Nome = "NomeAluno",
+                    UnidadeDeTamanho = EnumUnidadeDeTamanho.PERCENTUAL
+                },
+                new Coluna<FrequenciaMensalDto>()
+                {
+                    Largura = 8,
+                    Titulo = "AULAS",
+                    Nome = "QuantidadeAulas",
+                    UnidadeDeTamanho = EnumUnidadeDeTamanho.PERCENTUAL
+                },
+                new Coluna<FrequenciaMensalDto>()
+                {
+                    Largura = 8,
+                    Titulo = "AUSENC",
+                    Nome = "QuantidadeAusencias",
+                    UnidadeDeTamanho = EnumUnidadeDeTamanho.PERCENTUAL
+                },
+                new Coluna<FrequenciaMensalDto>()
+                {
+                    Largura = 8,
+                    Titulo = "COMP.",
+                    Nome = "QuantidadeCompensacoes",
                     UnidadeDeTamanho = EnumUnidadeDeTamanho.PERCENTUAL
                 },
                 new Coluna<FrequenciaMensalDto>()

--- a/src/SME.SR.Workers.SGP/Views/RelatorioPaginado/FrequenciaGlobalMensal/ConteudoCSS.cshtml
+++ b/src/SME.SR.Workers.SGP/Views/RelatorioPaginado/FrequenciaGlobalMensal/ConteudoCSS.cshtml
@@ -90,6 +90,11 @@
         padding-left: 8px;
     }
 
+    .alinhar-direita {
+        text-align: right;
+        padding-right: 8px;
+    }
+
     .espaco-esquerda-15 {
         padding-left: 15px;
     }

--- a/src/SME.SR.Workers.SGP/Views/RelatorioPaginado/FrequenciaGlobalMensal/ConteudoColuna.cshtml
+++ b/src/SME.SR.Workers.SGP/Views/RelatorioPaginado/FrequenciaGlobalMensal/ConteudoColuna.cshtml
@@ -41,7 +41,10 @@
 
             retorno += $@"<tr><th>{@linha.NumeroAluno}</th>";
             retorno += $@"<th class='alinhar-esquerda'>{@linha.NomeAluno}</th>";
-            retorno += $@"<th>{@linha.ProcentagemFrequencia}</th>";
+            retorno += $@"<th>{@linha.QuantidadeAulas}</th>";
+            retorno += $@"<th>{@linha.QuantidadeAusencias}</th>";
+            retorno += $@"<th>{@linha.QuantidadeCompensacoes}</th>";
+            retorno += $@"<th class='alinhar-direita'>{@linha.ProcentagemFrequencia}</th>";
             retorno += "</tr>";
 
         }

--- a/testes/SME.SR.Aplicacao.Teste/CasosDeUso/Relatorio/RelatorioFrequenciaGlobalUseCaseTest.cs
+++ b/testes/SME.SR.Aplicacao.Teste/CasosDeUso/Relatorio/RelatorioFrequenciaGlobalUseCaseTest.cs
@@ -1,0 +1,193 @@
+﻿using MediatR;
+using Moq;
+using Newtonsoft.Json;
+using SME.SR.Application;
+using SME.SR.Data;
+using SME.SR.Infra;
+
+namespace SME.SR.Aplicacao.Teste.CasosDeUso.Relatorio
+{
+    public class RelatorioFrequenciaGlobalUseCaseTest
+    {
+        private readonly Mock<IMediator> _mediatorMock;
+        private readonly RelatorioFrequenciaGlobalUseCase _useCase;
+
+        public RelatorioFrequenciaGlobalUseCaseTest()
+        {
+            _mediatorMock = new Mock<IMediator>();
+            _useCase = new RelatorioFrequenciaGlobalUseCase(_mediatorMock.Object);
+        }
+
+        [Fact]
+        public async Task Executar_QuandoFormatoForPdfEFiltroTodos_DeveGerarRelatorioPdfEEnviarLogs()
+        {
+            // Arrange
+            var filtro = CriarFiltroGlobalDto(TipoFormatoRelatorio.Pdf, ehFiltroTodos: true);
+            var request = CriarFiltroRelatorio(filtro);
+            var dadosRelatorio = CriarListaFrequenciaGlobalDto();
+
+            ConfigurarMocks(dadosRelatorio);
+
+            // Act
+            await _useCase.Executar(request);
+
+            // Assert
+            _mediatorMock.Verify(m => m.Send(It.IsAny<GerarRelatorioHtmlParaPdfCommand>(), It.IsAny<CancellationToken>()), Times.Once);
+            _mediatorMock.Verify(m => m.Send(It.IsAny<GerarExcelGenericoCommand>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task Executar_QuandoFormatoForXlsxEFiltroTodos_DeveGerarRelatorioXlsxEEnviarLogs()
+        {
+            // Arrange
+            var filtro = CriarFiltroGlobalDto(TipoFormatoRelatorio.Xlsx, ehFiltroTodos: true);
+            var request = CriarFiltroRelatorio(filtro);
+            var dadosRelatorio = CriarListaFrequenciaGlobalDto();
+
+            _mediatorMock
+                .Setup(m => m.Send(It.IsAny<ObterRelatorioDeFrequenciaGlobalQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(dadosRelatorio);
+
+            // Act
+            await _useCase.Executar(request);
+
+            // Assert
+            _mediatorMock.Verify(m => m.Send(It.IsAny<GerarExcelGenericoCommand>(), It.IsAny<CancellationToken>()), Times.Once);
+            _mediatorMock.Verify(m => m.Send(It.IsAny<GerarRelatorioHtmlParaPdfCommand>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task Executar_QuandoFormatoForPdfENaoForFiltroTodos_DeveGerarRelatorioPdfSemLogs()
+        {
+            // Arrange
+            var filtro = CriarFiltroGlobalDto(TipoFormatoRelatorio.Pdf, ehFiltroTodos: false);
+            var request = CriarFiltroRelatorio(filtro);
+            var dadosRelatorio = CriarListaFrequenciaGlobalDto();
+
+            ConfigurarMocks(dadosRelatorio);
+
+            // Act
+            await _useCase.Executar(request);
+
+            // Assert
+            _mediatorMock.Verify(m => m.Send(It.IsAny<SalvarLogViaRabbitCommand>(), It.IsAny<CancellationToken>()), Times.Never);
+            _mediatorMock.Verify(m => m.Send(It.IsAny<GerarRelatorioHtmlParaPdfCommand>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task Executar_QuandoFiltroRetornarNuloOuVazio_DeveLancarNegocioException()
+        {
+            // Arrange
+            var filtro = CriarFiltroGlobalDto(TipoFormatoRelatorio.Pdf, ehFiltroTodos: false);
+            var request = CriarFiltroRelatorio(filtro);
+
+            _mediatorMock
+                .Setup(m => m.Send(It.IsAny<ObterRelatorioDeFrequenciaGlobalQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<FrequenciaGlobalDto>());
+
+            // Act & Assert
+            var excecao = await Assert.ThrowsAsync<NegocioException>(() => _useCase.Executar(request));
+            Assert.Equal("Não foi possível localizar informações com os filtros selecionados", excecao.Message);
+        }
+
+        [Fact]
+        public async Task Executar_QuandoFormatoForInvalido_DeveLancarNegocioException()
+        {
+            // Arrange
+            var filtro = CriarFiltroGlobalDto((TipoFormatoRelatorio)99, ehFiltroTodos: false);
+            var request = CriarFiltroRelatorio(filtro);
+            var dadosRelatorio = CriarListaFrequenciaGlobalDto();
+
+            _mediatorMock
+                .Setup(m => m.Send(It.IsAny<ObterRelatorioDeFrequenciaGlobalQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(dadosRelatorio);
+
+            // Act & Assert
+            var excecao = await Assert.ThrowsAsync<NegocioException>(() => _useCase.Executar(request));
+            Assert.Contains("Não foi possível exportar este relátorio para o formato", excecao.Message);
+        }
+
+        [Fact]
+        public async Task Executar_QuandoQueryFalhar_DevePropagarExcecao()
+        {
+            // Arrange
+            var filtro = CriarFiltroGlobalDto(TipoFormatoRelatorio.Pdf, ehFiltroTodos: false);
+            var request = CriarFiltroRelatorio(filtro);
+
+            _mediatorMock
+                .Setup(m => m.Send(It.IsAny<ObterRelatorioDeFrequenciaGlobalQuery>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new ArgumentNullException());
+
+            // Act & Assert
+            await Assert.ThrowsAsync<ArgumentNullException>(() => _useCase.Executar(request));
+        }
+
+        #region Metodos Privados Auxiliares
+
+        private void ConfigurarMocks(List<FrequenciaGlobalDto> dadosRelatorio)
+        {
+            _mediatorMock
+                .Setup(m => m.Send(It.IsAny<ObterRelatorioDeFrequenciaGlobalQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(dadosRelatorio);
+
+            _mediatorMock
+                .Setup(m => m.Send(It.IsAny<ObterTurmaPorCodigoQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Turma { Nome = "Minha Turma" });
+
+            _mediatorMock
+                .Setup(m => m.Send(It.IsAny<ObterDreUePorDreCodigoQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new DreUe { DreNome = "DRE TESTE", UeNome = "UE TESTE" });
+
+            _mediatorMock
+                .Setup(m => m.Send(It.IsAny<ObterDrePorCodigoQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Dre() { Abreviacao = "DRE-TESTE", Nome = "DIRETORIA REGIONAL DE EDUCACAO TESTE" });
+        }
+
+        private FiltroRelatorioDto CriarFiltroRelatorio(FiltroFrequenciaGlobalDto filtro)
+        {
+            return new FiltroRelatorioDto
+            {
+                CodigoCorrelacao = Guid.NewGuid(),
+                Mensagem = JsonConvert.SerializeObject(filtro)
+            };
+        }
+
+        private FiltroFrequenciaGlobalDto CriarFiltroGlobalDto(TipoFormatoRelatorio formato, bool ehFiltroTodos)
+        {
+            return new FiltroFrequenciaGlobalDto
+            {
+                AnoLetivo = 2025,
+                CodigoDre = ehFiltroTodos ? "-99" : "108300",
+                CodigoUe = "-99",
+                Modalidade = Modalidade.EJA,
+                UsuarioNome = "Usuario Teste",
+                UsuarioRf = "1234567",
+                CodigosTurmas = new List<string> { "-99" },
+                MesesReferencias = new List<string> { "-99" },
+                TipoFormatoRelatorio = formato
+            };
+        }
+
+        private List<FrequenciaGlobalDto> CriarListaFrequenciaGlobalDto()
+        {
+            return new List<FrequenciaGlobalDto>
+            {
+                new FrequenciaGlobalDto
+                {
+                    DreCodigo = "108300",
+                    SiglaDre = "DRE-TESTE",
+                    UeCodigo = "123",
+                    UeNome = "ESCOLA TESTE",
+                    Mes = 1,
+                    TurmaCodigo = "T1",
+                    Turma = "TURMA 01",
+                    CodigoEOL = "EOL123",
+                    Estudante = "ALUNO TESTE",
+                    PercentualFrequencia = 95
+                }
+            };
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
Inclusão de campos para quantidade de aulas, ausências e compensações nos DTOs do relatório de frequência global, repositório e visualizações de relatórios paginados. Manipuladores e testes relacionados foram atualizados para oferecer suporte aos novos dados, melhorando a granularidade e a clareza do relatório.