### PR TITLE
Tratativa de turmas no Rel Frequencia Mensal

### DIFF
--- a/src/SME.SR.Data/Repositories/Sgp/FrequenciaAlunoRepository.cs
+++ b/src/SME.SR.Data/Repositories/Sgp/FrequenciaAlunoRepository.cs
@@ -616,6 +616,8 @@ namespace SME.SR.Data
 
             if (codigoDre != "-99")
                 query += " and d.dre_id = @codigoDre";
+            else
+                query += " and t.tipo_turma = @tipoTurma";
 
             if (codigoUe != "-99")
                 query += " and u.ue_id = @codigoUe";
@@ -641,6 +643,7 @@ namespace SME.SR.Data
             {
                 exibirHistorico,
                 anoLetivo,
+                tipoTurma = (int)TipoTurma.Regular,
                 codigoDre,
                 codigoUe,
                 modalidade,

--- a/testes/SME.SR.Aplicacao.Teste/Queries/ObterRelatorioDeFrequenciaGlobalQueryHandlerTest.cs
+++ b/testes/SME.SR.Aplicacao.Teste/Queries/ObterRelatorioDeFrequenciaGlobalQueryHandlerTest.cs
@@ -1,0 +1,221 @@
+﻿using MediatR;
+using Microsoft.Extensions.Configuration;
+using Moq;
+using SME.SR.Application;
+using SME.SR.Data;
+using SME.SR.Data.Interfaces;
+using SME.SR.Infra;
+
+namespace SME.SR.Aplicacao.Teste.Queries
+{
+    public class ObterRelatorioDeFrequenciaGlobalQueryHandlerTest
+    {
+        private readonly Mock<IFrequenciaAlunoRepository> _frequenciaRepositorioMock;
+        private readonly Mock<IMediator> _mediatorMock;
+        private readonly VariaveisAmbiente _variaveisAmbiente;
+        private readonly ObterRelatorioDeFrequenciaGlobalQueryHandler _handler;
+
+        private const int ANO_LETIVO = 2025;
+        private const int MES_REFERENCIA = 3;
+
+        public ObterRelatorioDeFrequenciaGlobalQueryHandlerTest()
+        {
+            _frequenciaRepositorioMock = new Mock<IFrequenciaAlunoRepository>();
+            _mediatorMock = new Mock<IMediator>();
+            var configuracaoEmMemoria = new Dictionary<string, string> {
+                { "ProcessamentoMaximoUes", "1" }
+            };
+            var configuration = new ConfigurationBuilder()
+                                .AddInMemoryCollection(configuracaoEmMemoria)
+                                .Build();
+            _variaveisAmbiente = new VariaveisAmbiente(configuration);
+
+            // Desabilita paralelismo para testes
+
+            _handler = new ObterRelatorioDeFrequenciaGlobalQueryHandler(
+                _frequenciaRepositorioMock.Object,
+                _mediatorMock.Object,
+                _variaveisAmbiente);
+        }
+
+        [Fact]
+        public async Task Handle_QuandoRepositorioRetornaNuloOuVazio_DeveRetornarListaVazia()
+        {
+            // Arrange
+            var filtro = new FiltroFrequenciaGlobalDto
+            {
+                CodigosTurmas = new List<string>(),
+                MesesReferencias = new List<string>()
+            };
+            var query = new ObterRelatorioDeFrequenciaGlobalQuery(filtro);
+            _frequenciaRepositorioMock.Setup(r => r.ObterFrequenciaAlunoMensal(It.IsAny<bool>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Modalidade>(),
+                                                                               It.IsAny<int>(), It.IsAny<string[]>(), It.IsAny<int[]>(), It.IsAny<int>()))
+                                      .ReturnsAsync(Enumerable.Empty<FrequenciaAlunoMensalConsolidadoDto>());
+
+            // Act
+            var resultado = await _handler.Handle(query, CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(resultado);
+            Assert.Empty(resultado);
+            _mediatorMock.Verify(m => m.Send(It.IsAny<IRequest<object>>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task Handle_QuandoFiltroDreEhEspecifica_DeveMapearCorretamente()
+        {
+            // Arrange
+            var filtro = CriarFiltro(codigoDre: "DRE-01");
+            var query = new ObterRelatorioDeFrequenciaGlobalQuery(filtro);
+
+            ConfigurarMocks(filtro, "Aluno Ativo", SituacaoMatriculaAluno.Ativo, new DateTime(ANO_LETIVO, MES_REFERENCIA, 10));
+
+            // Act
+            var resultado = await _handler.Handle(query, CancellationToken.None);
+
+            // Assert
+            Assert.Single(resultado);
+            Assert.Equal("Aluno Ativo", resultado.First().Estudante);
+            _mediatorMock.Verify(m => m.Send(It.IsAny<ObterDrePorCodigoQuery>(), It.IsAny<CancellationToken>()), Times.Once);
+            _mediatorMock.Verify(m => m.Send(It.IsAny<ObterDadosAlunosEscolaQuery>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task Handle_QuandoFiltroDreEhTodos_DeveMapearCorretamente()
+        {
+            // Arrange
+            var filtro = CriarFiltro(codigoDre: "-99");
+            var query = new ObterRelatorioDeFrequenciaGlobalQuery(filtro);
+
+            var frequenciaConsolidado = CriarFrequenciaConsolidada("Aluno Ativo", "DRE-01", "UE-01");
+            frequenciaConsolidado.AddRange(CriarFrequenciaConsolidada("Aluno Ativo 2", "DRE-02", "UE-02"));
+
+            _frequenciaRepositorioMock.Setup(r => r.ObterFrequenciaAlunoMensal(It.IsAny<bool>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Modalidade>(),
+                                                                               It.IsAny<int>(), It.IsAny<string[]>(), It.IsAny<int[]>(), It.IsAny<int>()))
+                                      .ReturnsAsync(frequenciaConsolidado);
+
+            _mediatorMock.Setup(m => m.Send(It.Is<ObterDadosAlunosEscolaQuery>(q => q.CodigoDre == "DRE-01"), It.IsAny<CancellationToken>()))
+                         .ReturnsAsync(CriarDadosAluno("Aluno Ativo", SituacaoMatriculaAluno.Ativo, new DateTime(ANO_LETIVO, MES_REFERENCIA, 10)));
+
+            _mediatorMock.Setup(m => m.Send(It.Is<ObterDadosAlunosEscolaQuery>(q => q.CodigoDre == "DRE-02"), It.IsAny<CancellationToken>()))
+                         .ReturnsAsync(CriarDadosAluno("Aluno Ativo 2", SituacaoMatriculaAluno.Ativo, new DateTime(ANO_LETIVO, MES_REFERENCIA, 10)));
+
+            // Act
+            var resultado = await _handler.Handle(query, CancellationToken.None);
+
+            // Assert
+            Assert.Equal(2, resultado.Count);
+            _mediatorMock.Verify(m => m.Send(It.IsAny<ObterDrePorCodigoQuery>(), It.IsAny<CancellationToken>()), Times.Never);
+            _mediatorMock.Verify(m => m.Send(It.IsAny<ObterDadosAlunosEscolaQuery>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
+        }
+
+        [Fact]
+        public async Task Handle_QuandoAlunoInativoNoMes_DeveConcatenarSituacaoNoNome()
+        {
+            // Arrange
+            var dataSituacao = new DateTime(ANO_LETIVO, MES_REFERENCIA, 15);
+            var filtro = CriarFiltro(codigoDre: "DRE-01");
+            var query = new ObterRelatorioDeFrequenciaGlobalQuery(filtro);
+
+            ConfigurarMocks(filtro, "Aluno Inativo", SituacaoMatriculaAluno.Transferido, dataSituacao);
+
+            // Act
+            var resultado = await _handler.Handle(query, CancellationToken.None);
+
+            // Assert
+            Assert.Single(resultado);
+            Assert.Contains(" - Transferido 15/03/2025", resultado.First().Estudante);
+        }
+
+        [Fact]
+        public async Task Handle_QuandoAlunoInativoAntesDoMes_NaoDeveIncluirNoRelatorio()
+        {
+            // Arrange
+            var dataSituacao = new DateTime(ANO_LETIVO, MES_REFERENCIA - 1, 15); // Inativo no mês anterior
+            var filtro = CriarFiltro(codigoDre: "DRE-01");
+            var query = new ObterRelatorioDeFrequenciaGlobalQuery(filtro);
+
+            ConfigurarMocks(filtro, "Aluno Inativo Antigo", SituacaoMatriculaAluno.Transferido, dataSituacao);
+
+            // Act
+            var resultado = await _handler.Handle(query, CancellationToken.None);
+
+            // Assert
+            Assert.Empty(resultado);
+        }
+
+        #region Metodos Privados Auxiliares
+
+        private void ConfigurarMocks(FiltroFrequenciaGlobalDto filtro, string nomeAluno, SituacaoMatriculaAluno situacao, DateTime dataSituacao)
+        {
+            _frequenciaRepositorioMock.Setup(r => r.ObterFrequenciaAlunoMensal(It.IsAny<bool>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Modalidade>(),
+                                                                               It.IsAny<int>(), It.IsAny<string[]>(), It.IsAny<int[]>(), It.IsAny<int>()))
+                                      .ReturnsAsync(CriarFrequenciaConsolidada(nomeAluno, filtro.CodigoDre, "UE-01"));
+
+            _mediatorMock.Setup(m => m.Send(It.Is<ObterDrePorCodigoQuery>(q => q.DreCodigo == filtro.CodigoDre), It.IsAny<CancellationToken>()))
+                         .ReturnsAsync(new Dre { Codigo = filtro.CodigoDre, Nome = "DRE TESTE" });
+
+            _mediatorMock.Setup(m => m.Send(It.IsAny<ObterDadosAlunosEscolaQuery>(), It.IsAny<CancellationToken>()))
+                         .ReturnsAsync(CriarDadosAluno(nomeAluno, situacao, dataSituacao));
+        }
+
+        private FiltroFrequenciaGlobalDto CriarFiltro(string codigoDre)
+        {
+            return new FiltroFrequenciaGlobalDto
+            {
+                AnoLetivo = ANO_LETIVO,
+                CodigoDre = codigoDre,
+                CodigoUe = "-99",
+                Modalidade = Modalidade.EJA,
+                CodigosTurmas = new List<string> { "-99" },
+                MesesReferencias = new List<string> { MES_REFERENCIA.ToString() }
+            };
+        }
+
+        private List<FrequenciaAlunoMensalConsolidadoDto> CriarFrequenciaConsolidada(string nomeAluno, string codigoDre, string codigoUe)
+        {
+            return new List<FrequenciaAlunoMensalConsolidadoDto>
+            {
+                new FrequenciaAlunoMensalConsolidadoDto
+                {
+                    DreSigla = "DRE-SIGLA",
+                    DreCodigo = codigoDre,
+                    UeNome = "ESCOLA TESTE",
+                    UeCodigo = codigoUe,
+                    DescricaoTipoEscola = "EMEF",
+                    Mes = MES_REFERENCIA,
+                    ModalidadeCodigo = (int)Modalidade.EJA,
+                    TurmaNome = "TURMA 01",
+                    TurmaCodigo = "T-01",
+                    CodigoEol = "12345",
+                    Percentual = 90,
+                    QuantidadeAulas = 100,
+                    QuantidadeAusencias = 10,
+                    QuantidadeCompensacoes = 0
+                }
+            };
+        }
+
+        private IEnumerable<DadosAlunosEscolaDto> CriarDadosAluno(string nomeAluno, SituacaoMatriculaAluno situacao, DateTime dataSituacao)
+        {
+            return new List<DadosAlunosEscolaDto>
+            {
+                new DadosAlunosEscolaDto
+                {
+                    CodigoAluno = 12345,
+                    NomeAluno = nomeAluno,
+                    NomeSocialAluno = "",
+                    CodigoSituacaoMatricula = (int)situacao,
+                    SituacaoMatricula = situacao.ToString(),
+                    DataSituacao = dataSituacao,
+                    DataMatricula = new DateTime(ANO_LETIVO, 1, 20),
+                    NumeroAlunoChamada = "10",
+                    CodigoTurma = "T-01",
+                    AnoLetivo = ANO_LETIVO
+                }
+            };
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
Apresenta testes unitários abrangendo vários cenários para ObterRelatorioDeFrequenciaGlobalQueryHandler, incluindo o tratamento de resultados vazios, filtros DRE específicos e todos os filtros, e lógica de status do aluno. Também atualiza o FrequenciaAlunoRepository para tratar o parâmetro tipoTurma quando codigoDre for '-99'.